### PR TITLE
feat: Use UI5 namespace instead of package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,45 +1,44 @@
 {
-  "name": "npmpackagesample",
-  "version": "0.0.1",
-  "scripts": {
-    "start": "ui5 serve --config=uimodule/ui5.yaml  --open index.html",
-    "start-nodemon": "nodemon app.js localhost 8888",
-    "build:ui": "run-s  build:uimodule",
-    "test": "run-s lint karma",
-    "karma-ci": "karma start karma-ci.conf.js",
-    "clearCoverage": "shx rm -rf coverage",
-    "karma": "run-s clearCoverage karma-ci",
-    "lint": "eslint ./**/webapp/**/*.js && prettier --check ./**/webapp/**/*.{js,xml}",
-    "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --write ./**/webapp/**/*.{js,xml}",
-    "serve:uimodule": "ui5 serve --config=uimodule/ui5.yaml",
-    "build:uimodule": "ui5 build --config=uimodule/ui5.yaml --clean-dest --a --dest uimodule/dist --include-task=generateManifestBundle"
-  },
-  "dependencies": {
-    "cors-anywhere": "^0.4.4",
-    "express": "^4.16.4"
-  },
-  "devDependencies": {
-    "@marianfoo/ui5-errorhandler": "^0.0.4",
-    "@prettier/plugin-xml": "^1.1.0",
-    "@sap/eslint-plugin-ui5-jsdocs": "^2.0.5",
-    "@sapui5/ts-types": "^1.96.0",
-    "@ui5/cli": "^2.14.1",
-    "eslint": "^7.32.0",
-    "karma": "^6.3.9",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-coverage": "^2.1.0",
-    "karma-ui5": "^2.3.4",
-    "nodemon": "^2.0.12",
-    "npm-run-all": "^4.1.5",
-    "prettier": "^2.5.1",
-    "shx": "^0.3.3",
-    "ui5-middleware-livereload": "^0.5.8",
-    "ui5-tooling-modules": "^0.1.2"
-  },
-  "ui5": {
-    "dependencies": [
-      "ui5-middleware-livereload",
-      "ui5-tooling-modules"
-    ]
-  }
+    "name": "npmpackagesample",
+    "version": "0.0.1",
+    "scripts": {
+        "start": "ui5 serve --config=uimodule/ui5.yaml  --open index.html",
+        "start-nodemon": "nodemon app.js localhost 8888",
+        "build:ui": "run-s  build:uimodule",
+        "test": "run-s lint karma",
+        "karma-ci": "karma start karma-ci.conf.js",
+        "clearCoverage": "shx rm -rf coverage",
+        "karma": "run-s clearCoverage karma-ci",
+        "lint": "eslint ./**/webapp/**/*.js && prettier --check ./**/webapp/**/*.{js,xml}",
+        "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --write ./**/webapp/**/*.{js,xml}",
+        "serve:uimodule": "ui5 serve --config=uimodule/ui5.yaml",
+        "build:uimodule": "ui5 build --config=uimodule/ui5.yaml --clean-dest --a --dest uimodule/dist --include-task=generateManifestBundle"
+    },
+    "dependencies": {
+        "cors-anywhere": "^0.4.4",
+        "express": "^4.16.4"
+    },
+    "devDependencies": {
+        "@marianfoo/ui5-errorhandler": "^0.0.4",
+        "@prettier/plugin-xml": "^1.1.0",
+        "@sap/eslint-plugin-ui5-jsdocs": "^2.0.5",
+        "@sapui5/ts-types": "^1.96.0",
+        "@ui5/cli": "^2.14.1",
+        "eslint": "^7.32.0",
+        "karma": "^6.3.9",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-coverage": "^2.1.0",
+        "karma-ui5": "^2.3.4",
+        "nodemon": "^2.0.12",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.5.1",
+        "shx": "^0.3.3",
+        "ui5-middleware-simpleproxy": "^0.7.6"
+    },
+    "ui5": {
+        "dependencies": [
+            "ui5-middleware-simpleproxy",
+            "@marianfoo/ui5-errorhandler"
+        ]
+    }
 }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     },
     "dependencies": {
         "cors-anywhere": "^0.4.4",
-        "express": "^4.16.4"
+        "express": "^4.16.4",
+        "@marianfoo/ui5-errorhandler": "^0.0.4"
     },
     "devDependencies": {
-        "@marianfoo/ui5-errorhandler": "^0.0.4",
         "@prettier/plugin-xml": "^1.1.0",
         "@sap/eslint-plugin-ui5-jsdocs": "^2.0.5",
         "@sapui5/ts-types": "^1.96.0",

--- a/uimodule/ui5.yaml
+++ b/uimodule/ui5.yaml
@@ -1,24 +1,23 @@
 specVersion: "2.2"
 metadata:
-  name: npmpackagesample_uimodule
+    name: npmpackagesample_uimodule
 type: application
 resources:
-  configuration:
-    paths:
-      webapp: uimodule/webapp
+    configuration:
+        paths:
+            webapp: uimodule/webapp
 framework:
-  name: OpenUI5
-  version: 1.96.0
-  libraries:
-    - name: sap.ui.core
-    - name: sap.m
-    - name: sap.ui.layout
-    - name: themelib_sap_fiori_3
+    name: OpenUI5
+    version: 1.96.0
+    libraries:
+        - name: sap.ui.core
+        - name: sap.m
+        - name: sap.ui.layout
+        - name: themelib_sap_fiori_3
 server:
-  customMiddleware:
-    - name: ui5-tooling-modules-middleware
-      afterMiddleware: compression
-builder:
-  customTasks:
-  - name: ui5-tooling-modules-task
-    afterTask: replaceVersion
+    customMiddleware:
+        - name: ui5-middleware-simpleproxy
+          afterMiddleware: compression
+          mountPath: /V2
+          configuration:
+              baseUri: "https://services.odata.org/V2"

--- a/uimodule/webapp/Component.js
+++ b/uimodule/webapp/Component.js
@@ -1,5 +1,5 @@
 sap.ui.define(
-    ["sap/ui/core/UIComponent", "sap/ui/Device", "de/marianzeis/npmpackagesample/model/models",  "@marianfoo/ui5-errorhandler/ErrorHandler"],
+    ["sap/ui/core/UIComponent", "sap/ui/Device", "de/marianzeis/npmpackagesample/model/models", "de/marianzeis/ui5-errorhandler/ErrorHandler"],
     /**
      * @param {typeof sap.ui.core.UIComponent} UIComponent
      * @param {typeof sap.ui.Device} Device

--- a/uimodule/webapp/controller/MainView.controller.js
+++ b/uimodule/webapp/controller/MainView.controller.js
@@ -7,11 +7,10 @@ sap.ui.define(
         "use strict";
 
         return Controller.extend("de.marianzeis.npmpackagesample.controller.MainView", {
-            onInit: function () {
+            onInit: function () {},
+            dataRequest: function (event, number) {
+                this.getOwnerComponent().getModel().read(`/Products(${number})`);
             },
-            dataRequest: function(event, number){
-                this.getOwnerComponent().getModel().read(`/Products(${number})`)
-              }
         });
     }
 );

--- a/uimodule/webapp/manifest.json
+++ b/uimodule/webapp/manifest.json
@@ -1,104 +1,102 @@
 {
-  "_version": "1.12.0",
-  "sap.app": {
-    "id": "de.marianzeis.npmpackagesample",
-    "type": "application",
-    "i18n": "i18n/i18n.properties",
-    "applicationVersion": {
-      "version": "0.0.1"
+    "_version": "1.12.0",
+    "sap.app": {
+        "id": "de.marianzeis.npmpackagesample",
+        "type": "application",
+        "i18n": "i18n/i18n.properties",
+        "applicationVersion": {
+            "version": "0.0.1"
+        },
+        "title": "{{appTitle}}",
+        "description": "{{appDescription}}",
+        "dataSources": {
+            "northwind": {
+                "uri": "/V2/Northwind/Northwind.svc/",
+                "type": "OData",
+                "settings": {
+                    "odataVersion": "2.0"
+                }
+            }
+        }
     },
-    "title": "{{appTitle}}",
-    "description": "{{appDescription}}",
-    "dataSources" : {
-      "northwind" : {
-        "uri": "http://localhost:8888/https://services.odata.org/V2/Northwind/Northwind.svc/",
-		    "type": "OData",
-		    "settings": {
-		      "odataVersion": "2.0"
-		    }
-      }
+    "sap.ui": {
+        "technology": "UI5",
+        "icons": {
+            "icon": "",
+            "favIcon": "",
+            "phone": "",
+            "phone@2": "",
+            "tablet": "",
+            "tablet@2": ""
+        },
+        "deviceTypes": {
+            "desktop": true,
+            "tablet": true,
+            "phone": true
+        }
+    },
+    "sap.ui5": {
+        "flexEnabled": true,
+        "dependencies": {
+            "minUI5Version": "1.60",
+            "libs": {
+                "sap.ui.core": {}
+            }
+        },
+        "contentDensities": {
+            "compact": true,
+            "cozy": true
+        },
+        "models": {
+            "i18n": {
+                "type": "sap.ui.model.resource.ResourceModel",
+                "settings": {
+                    "bundleName": "de.marianzeis.npmpackagesample.i18n.i18n"
+                }
+            },
+            "": {
+                "dataSource": "northwind"
+            }
+        },
+        "resources": {
+            "css": [
+                {
+                    "uri": "css/style.css"
+                }
+            ]
+        },
+        "routing": {
+            "config": {
+                "routerClass": "sap.m.routing.Router",
+                "viewType": "XML",
+                "async": true,
+                "viewPath": "de.marianzeis.npmpackagesample.view",
+                "controlAggregation": "pages",
+                "controlId": "app",
+                "clearControlAggregation": false
+            },
+            "routes": [
+                {
+                    "name": "RouteMainView",
+                    "pattern": "RouteMainView",
+                    "target": ["TargetMainView"]
+                }
+            ],
+            "targets": {
+                "TargetMainView": {
+                    "viewType": "XML",
+                    "transition": "slide",
+                    "clearControlAggregation": false,
+                    "viewId": "MainView",
+                    "viewName": "MainView"
+                }
+            }
+        },
+        "rootView": {
+            "viewName": "de.marianzeis.npmpackagesample.view.MainView",
+            "type": "XML",
+            "async": true,
+            "id": "MainView"
+        }
     }
-  },
-  "sap.ui": {
-    "technology": "UI5",
-    "icons": {
-      "icon": "",
-      "favIcon": "",
-      "phone": "",
-      "phone@2": "",
-      "tablet": "",
-      "tablet@2": ""
-    },
-    "deviceTypes": {
-      "desktop": true,
-      "tablet": true,
-      "phone": true
-    }
-  },
-  "sap.ui5": {
-    "flexEnabled": true,
-    "dependencies": {
-      "minUI5Version": "1.60",
-      "libs": {
-        "sap.ui.core": {}
-      }
-    },
-    "contentDensities": {
-      "compact": true,
-      "cozy": true
-    },
-    "models": {
-      "i18n": {
-        "type": "sap.ui.model.resource.ResourceModel",
-        "settings": {
-          "bundleName": "de.marianzeis.npmpackagesample.i18n.i18n"
-        }
-      },
-      "": {
-        "dataSource": "northwind"
-        }
-    },
-    "resources": {
-      "css": [
-        {
-          "uri": "css/style.css"
-        }
-      ]
-    },
-    "routing": {
-      "config": {
-        "routerClass": "sap.m.routing.Router",
-        "viewType": "XML",
-        "async": true,
-        "viewPath": "de.marianzeis.npmpackagesample.view",
-        "controlAggregation": "pages",
-        "controlId": "app",
-        "clearControlAggregation": false
-      },
-      "routes": [
-        {
-          "name": "RouteMainView",
-          "pattern": "RouteMainView",
-          "target": [
-            "TargetMainView"
-          ]
-        }
-      ],
-      "targets": {
-        "TargetMainView": {
-          "viewType": "XML",
-          "transition": "slide",
-          "clearControlAggregation": false,
-          "viewId": "MainView",
-          "viewName": "MainView"
-        }
-      }
-    },
-    "rootView": {
-      "viewName": "de.marianzeis.npmpackagesample.view.MainView",
-      "type": "XML",
-      "async": true,
-      "id": "MainView"
-    }
-  }
 }

--- a/uimodule/webapp/view/MainView.view.xml
+++ b/uimodule/webapp/view/MainView.view.xml
@@ -4,8 +4,8 @@
             <pages>
                 <Page id="page" title="{i18n>title}">
                     <content>
-                        <Button text="Test button" press=".dataRequest($event, 1)"/>
-                        <Button text="Test button with error" press=".dataRequest($event, 14444444444444)"/>
+                        <Button text="Test button" press=".dataRequest($event, 1)" />
+                        <Button text="Test button with error" press=".dataRequest($event, 14444444444444)" />
                     </content>
                 </Page>
             </pages>


### PR DESCRIPTION
Hi @marianfoo,
like discussed on twitter you don't need ui5-tooling-modules in that case and can rely on the ui5 tooling itself. 

P.S. I forgot to turn off autoformat after save, sry...

Best regards,
Marcel